### PR TITLE
factory: Correct CancellationToken handling

### DIFF
--- a/Bede.Thallium/Factory.cs
+++ b/Bede.Thallium/Factory.cs
@@ -300,13 +300,14 @@ namespace Bede.Thallium
                 if (caTok != null)
                 {
                     ilG.Emit(OpCodes.Ldarg, caTok.Position + 1);
-
                     ilG.EmitNullConversion(caTok.ParameterType);
                 }
                 else
                 {
-                    ilG.Emit(OpCodes.Ldnull);
-                    ilG.Emit(OpCodes.Castclass, typeof(CancellationToken?));
+                    LocalBuilder caTokF = ilG.DeclareLocal(typeof(CancellationToken?));
+                    ilG.Emit(OpCodes.Ldloca, caTokF);
+                    ilG.Emit(OpCodes.Initobj, typeof(CancellationToken?));
+                    ilG.Emit(OpCodes.Ldloc, caTokF);
                 }
 
                 // Call SendAsync

--- a/Bede.Thallium/I.cs
+++ b/Bede.Thallium/I.cs
@@ -78,13 +78,7 @@ namespace Bede.Thallium
 
             if (nt != source)
             {
-                var br = @this.DefineLabel();
-                @this.Emit(OpCodes.Dup);
-                @this.Emit(OpCodes.Brfalse, br);
-
                 @this.Emit(OpCodes.Newobj, nt.GetConstructor(new [] { source }));
-
-                @this.MarkLabel(br);
             }
         }
     }

--- a/Tests/Bede.Thallium.UnitTests/Generation.cs
+++ b/Tests/Bede.Thallium.UnitTests/Generation.cs
@@ -154,13 +154,23 @@ namespace Bede.Thallium.UnitTests
         {
             var sut = Api.Rest().New<IStaticHeader>(new Uri("http://localhost"), _server);
 
-            Assert.DoesNotThrow(() => sut.Post(1).Wait());
+            Assert.DoesNotThrow(() => sut.Post().Wait());
         }
 
         [Test]
         public void Exceptions()
         {
             Assert.Throws<ArgumentNullException>(() => Api.Rest().New<IFoo>(null));
+        }
+
+        [Test]
+        public void Cancellation()
+        {
+            var sut = Api.Rest().New<ICancellationToken>(new Uri("http://localhost"), _server);
+
+            sut.None().Wait();
+            sut.Value().Wait();
+            sut.Nullable().Wait();
         }
     }
 
@@ -215,6 +225,18 @@ namespace Bede.Thallium.UnitTests
     public interface IStaticHeader
     {
         [Post]
-        Task Post(long body);
+        Task Post();
+    }
+
+    public interface ICancellationToken
+    {
+        [Get]
+        Task None();
+
+        [Get]
+        Task Value(CancellationToken token = default(CancellationToken));
+
+        [Get]
+        Task Nullable(CancellationToken? token = null);
     }
 }


### PR DESCRIPTION
The emitted IL we were using was handled okay by the .NET framework but
not on mono - it looks like the framework gives us some leeway when
handling value types, e.g. Nullable<CancellationToken>